### PR TITLE
Bump capybara from 3.39.2 to 3.40.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,11 +83,11 @@ GEM
     brakeman (6.2.1)
       racc
     builder (3.3.0)
-    capybara (3.39.2)
+    capybara (3.40.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
+      nokogiri (~> 1.11)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)


### PR DESCRIPTION
- Fixes error "Minitest::UnexpectedError: NameError: uninitialized constant Rack::Handler"