### PR TITLE
Potential fix for code scanning alert no. 584: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/jbakerdev/web/security/code-scanning/584](https://github.com/jbakerdev/web/security/code-scanning/584)

To fix the problem, we should add a `permissions` block to the workflow or the specific job. Since there is only one job in this workflow, we can add the `permissions` block at either the root level (applies to all jobs) or directly under the `deploy` job. The minimal required permission for this workflow is likely `contents: read`, as it checks out code and deploys using a secret, but does not appear to need write access to repository contents, issues, or pull requests. The fix involves adding the following block:

```yaml
permissions:
  contents: read
```

This should be placed at the root level, just after the `name` and before the `on` block, or under the `deploy` job. The recommended approach is to add it at the root level for clarity and future extensibility.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
